### PR TITLE
对输入换行和程序崩溃问题做了一些初步的处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.cfg
 main.exe
 .idea
 main
+QQ-ChatGPT-Bot

--- a/cmd/chatgpt/chatgpt.go
+++ b/cmd/chatgpt/chatgpt.go
@@ -54,6 +54,8 @@ func Client() (http.Client, error) {
 // GenerateText 调用openai的API生成文本
 func GenerateText(text string) string {
 	log.Println("正在调用OpenAI API生成文本...", text)
+	text = strings.ReplaceAll(text, "\r", "")
+	text = strings.ReplaceAll(text, "\n", "\\n")
 	postData := []byte(fmt.Sprintf(`{
 	  "model": "%s",
 	  "messages": %s,

--- a/cmd/chatgpt/chatgpt.go
+++ b/cmd/chatgpt/chatgpt.go
@@ -54,6 +54,8 @@ func Client() (http.Client, error) {
 // GenerateText 调用openai的API生成文本
 func GenerateText(text string) string {
 	log.Println("正在调用OpenAI API生成文本...", text)
+	text = strings.ReplaceAll(text, "\r", "")
+	text = strings.ReplaceAll(text, "\n", "\\n")
 	postData := []byte(fmt.Sprintf(`{
 	  "model": "%s",
 	  "messages": %s,
@@ -70,6 +72,7 @@ func GenerateText(text string) string {
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Println(err)
+		return ""
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)

--- a/cmd/chatgpt/chatgpt.go
+++ b/cmd/chatgpt/chatgpt.go
@@ -70,6 +70,7 @@ func GenerateText(text string) string {
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Println(err)
+		return ""
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)

--- a/cmd/chatgpt/chatgpt.go
+++ b/cmd/chatgpt/chatgpt.go
@@ -70,7 +70,6 @@ func GenerateText(text string) string {
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Println(err)
-		return ""
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)

--- a/cmd/chatgpt/chatgpt.go
+++ b/cmd/chatgpt/chatgpt.go
@@ -75,6 +75,10 @@ func GenerateText(text string) string {
 		return ""
 	}
 	defer resp.Body.Close()
+	if resp == nil {
+		log.Println("response is nil")
+		return ""
+	}
 	body, _ := io.ReadAll(resp.Body)
 	var openAiRcv OpenAiRcv
 	err = json.Unmarshal(body, &openAiRcv)

--- a/cmd/chatgpt/chatgpt.go
+++ b/cmd/chatgpt/chatgpt.go
@@ -54,8 +54,6 @@ func Client() (http.Client, error) {
 // GenerateText 调用openai的API生成文本
 func GenerateText(text string) string {
 	log.Println("正在调用OpenAI API生成文本...", text)
-	text = strings.ReplaceAll(text, "\r", "")
-	text = strings.ReplaceAll(text, "\n", "\\n")
 	postData := []byte(fmt.Sprintf(`{
 	  "model": "%s",
 	  "messages": %s,

--- a/cmd/cqhttp/message.go
+++ b/cmd/cqhttp/message.go
@@ -48,7 +48,13 @@ func (bot *Bot) HandleMsg(isAt bool, rcvMsg RcvMsg) {
 	switch rcvMsg.MessageType {
 	case "private":
 		bot.MQ <- &rcvMsg
-		err := bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+chatgpt.GenerateText(rcvMsg.Message))
+		msg := chatgpt.GenerateText(rcvMsg.Message)
+		var err error
+		if msg != "" {
+			err = bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+msg)
+		} else {
+			err = bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+"生成错误！")
+		}
 		if err != nil {
 			log.Println(err)
 		}
@@ -59,7 +65,13 @@ func (bot *Bot) HandleMsg(isAt bool, rcvMsg RcvMsg) {
 			return
 		}
 		bot.MQ <- &rcvMsg
-		err := bot.SendGroupMsg(rcvMsg.GroupId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+chatgpt.GenerateText(rcvMsg.Message))
+		msg := chatgpt.GenerateText(rcvMsg.Message)
+		var err error
+		if msg != "" {
+			err = bot.SendGroupMsg(rcvMsg.GroupId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+chatgpt.GenerateText(rcvMsg.Message))
+		} else {
+			err = bot.SendGroupMsg(rcvMsg.GroupId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+"生成错误！")
+		}
 		if err != nil {
 			log.Println(err)
 		}

--- a/cmd/cqhttp/message.go
+++ b/cmd/cqhttp/message.go
@@ -48,14 +48,7 @@ func (bot *Bot) HandleMsg(isAt bool, rcvMsg RcvMsg) {
 	switch rcvMsg.MessageType {
 	case "private":
 		bot.MQ <- &rcvMsg
-		//假如生成信息错误，直接处理掉，避免程序因为错误信息崩溃。不过没细看为什么会出现错误。
-		msg := chatgpt.GenerateText(rcvMsg.Message)
-		var err error
-		if msg == "" {
-			err = bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+"生成失败！")
-		} else {
-			err = bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+msg)
-		}
+		err := bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+chatgpt.GenerateText(rcvMsg.Message))
 		if err != nil {
 			log.Println(err)
 		}
@@ -66,13 +59,7 @@ func (bot *Bot) HandleMsg(isAt bool, rcvMsg RcvMsg) {
 			return
 		}
 		bot.MQ <- &rcvMsg
-		msg := chatgpt.GenerateText(rcvMsg.Message)
-		var err error
-		if msg == "" {
-			err = bot.SendGroupMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+"生成失败！")
-		} else {
-			err = bot.SendGroupMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+msg)
-		}
+		err := bot.SendGroupMsg(rcvMsg.GroupId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+chatgpt.GenerateText(rcvMsg.Message))
 		if err != nil {
 			log.Println(err)
 		}

--- a/cmd/cqhttp/message.go
+++ b/cmd/cqhttp/message.go
@@ -48,7 +48,14 @@ func (bot *Bot) HandleMsg(isAt bool, rcvMsg RcvMsg) {
 	switch rcvMsg.MessageType {
 	case "private":
 		bot.MQ <- &rcvMsg
-		err := bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+chatgpt.GenerateText(rcvMsg.Message))
+		//假如生成信息错误，直接处理掉，避免程序因为错误信息崩溃。不过没细看为什么会出现错误。
+		msg := chatgpt.GenerateText(rcvMsg.Message)
+		var err error
+		if msg == "" {
+			err = bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+"生成失败！")
+		} else {
+			err = bot.SendPrivateMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+msg)
+		}
 		if err != nil {
 			log.Println(err)
 		}
@@ -59,7 +66,13 @@ func (bot *Bot) HandleMsg(isAt bool, rcvMsg RcvMsg) {
 			return
 		}
 		bot.MQ <- &rcvMsg
-		err := bot.SendGroupMsg(rcvMsg.GroupId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+chatgpt.GenerateText(rcvMsg.Message))
+		msg := chatgpt.GenerateText(rcvMsg.Message)
+		var err error
+		if msg == "" {
+			err = bot.SendGroupMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+"生成失败！")
+		} else {
+			err = bot.SendGroupMsg(rcvMsg.Sender.UserId, "[CQ:reply,id="+strconv.FormatInt(rcvMsg.MessageId, 10)+"]"+msg)
+		}
 		if err != nil {
 			log.Println(err)
 		}


### PR DESCRIPTION
纯新手，也只是参考chatgpt的意见大概处理了一下，不过确实能换行输入了。在chatgp.go中把传入的text里的“/n”和“/r”做了替换，程序就可以正确处理换行了。在处理一些其他输入信息的时候还是会有些问题，比如输入一大段c语言代码的时候还是会报错。应该还是转化成JSON格式的时候出了问题。
(注：去问了下chatgpt，现在已经解决了JSON格式化的时候出现的转义问题了）
另外有时候会出现这个问题（我也不太清楚是为什么，所以只是做了一个错误的处理，防止程序因为空指针崩溃）：

> 2023/03/25 12:55:23 chatgpt.go:72: Post "https://api.openai.com/v1/chat/completions": read tcp 127.0.0.1:40578->127.0.0.1:7890: read: connection reset by peer
> panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x6fc4b3]
> 
> goroutine 747 [running]:
> QQ-ChatGPT-Bot/cmd/chatgpt.GenerateText({0xc0000a4350, 0x3})
> 	/home/runner/work/QQ-ChatGPT-Bot/QQ-ChatGPT-Bot/cmd/chatgpt/chatgpt.go:74 +0x5b3
> QQ-ChatGPT-Bot/cmd/cqhttp.(*Bot).HandleMsg(0xa06720, 0x0, {{0xc0000a4018, 0x7}, {0xc0000a4070, 0x7}, 0x641e7eb6, 0x76cd0a6f, {0xc0000a4078, 0x6}, ...})
> 	/home/runner/work/QQ-ChatGPT-Bot/QQ-ChatGPT-Bot/cmd/cqhttp/message.go:51 +0x267
> created by QQ-ChatGPT-Bot/cmd/cqhttp.(*Bot).Read
> 	/home/runner/work/QQ-ChatGPT-Bot/QQ-ChatGPT-Bot/cmd/cqhttp/login.go:65 +0x2b6

所以在chatgpt.go的一些地方加了return语句，并且做了一个判断。如果返回“”就给用户发送生成失败，防止程序直接崩溃掉（免得我每次都自己动手去重启程序）。
不过之后没有遇到过上面的那个问题了，所以也没检验过这么做行不行。
（刚刚遇到了，确实行）

